### PR TITLE
Fairly serious bug fix for 32 bit systems

### DIFF
--- a/lib/Crypt/OpenPGP/Util.pm
+++ b/lib/Crypt/OpenPGP/Util.pm
@@ -23,9 +23,9 @@ sub bin2bigint { $_[0] ? Math::BigInt->new('0x' . unpack 'H*', $_[0]) : 0 }
 sub bigint2bin {
     my($p) = @_;
         
-	$p = _ensure_bigint($p);
+    $p = _ensure_bigint($p);
     
-    my $base = 1 << 4*8;
+    my $base = _ensure_bigint(1) << _ensure_bigint(4*8);
     my $res = '';
     while ($p != 0) {
         my $r = $p % $base;


### PR DESCRIPTION
Uncovered an issue on 32 bit systems, where integers were getting lost, due to some numbers not being big ints. This meant bigint2bin() would loop forever (and the tests hung). Apologies for this - I missed it as all my testing had been on 64 bit systems.
