### PR TITLE
Anchor ASCII armor detection to the start of the file, to avoid false pos

### DIFF
--- a/lib/Crypt/OpenPGP/KeyRing.pm
+++ b/lib/Crypt/OpenPGP/KeyRing.pm
@@ -30,7 +30,7 @@ sub init {
         { local $/; $ring->{_data} = <FH> }
         close FH;
     }
-    if ($ring->{_data} =~ /-----BEGIN/) {
+    if ($ring->{_data} =~ /^-----BEGIN/) {
         require Crypt::OpenPGP::Armour;
         my $rec = Crypt::OpenPGP::Armour->unarmour($ring->{_data}) or
             return (ref $ring)->error("Unarmour failed: " .


### PR DESCRIPTION
Anchor ASCII armor detection to the start of the file, to avoid false positives.
