### PR TITLE
Fix error propagation on generating RSA key

### DIFF
--- a/lib/Crypt/OpenPGP/Key/Public/RSA.pm
+++ b/lib/Crypt/OpenPGP/Key/Public/RSA.pm
@@ -29,7 +29,7 @@ sub keygen {
     require Crypt::RSA::Key;
     my $chain = Crypt::RSA::Key->new;
     my($pub, $sec) = $chain->generate( %param );
-    return $class->errstr( $chain->errstr ) unless $pub && $sec;
+    return $class->error( $chain->errstr ) unless $pub && $sec;
     ($pub, $sec);
 }
 

--- a/t/13-keygen.t
+++ b/t/13-keygen.t
@@ -1,5 +1,5 @@
 use strict;
-use Test::More tests => 28;
+use Test::More tests => 29;
 
 use Crypt::OpenPGP;
 use Crypt::OpenPGP::Message;
@@ -49,4 +49,23 @@ for my $type ( qw( RSA DSA ) ) {
 
     is $pieces[0]->key_id, $sec->key->key_id,
         'serialized public key_id matches secret key_id';
+}
+
+{
+    *Crypt::RSA::Key::generate = sub {
+        my ($self, %params) = @_;
+        return $self->error("d is too small. Regenerate.");
+    };
+
+    my($pub, $sec) = Crypt::OpenPGP::Key->keygen(
+        'RSA',
+        Size    => $bits,
+        Version => 4,
+    );
+
+    is(
+        Crypt::OpenPGP::Key->errstr,
+        "Key generation failed: d is too small. Regenerate.\n",
+        'RSA key generation error got propagated',
+    );
 }


### PR DESCRIPTION
If generating an RSA key fails, the error message got lost, since
$class->errstr is a read accessor. Have to use $class->error to set the
error.