### PR TITLE
Update GnuPG defaults.

### DIFF
--- a/lib/Crypt/OpenPGP.pm
+++ b/lib/Crypt/OpenPGP.pm
@@ -79,11 +79,11 @@ $Crypt::OpenPGP::Globals::Trim_trailing_ws = 1;
         },
 
         GnuPG => {
-              'sign'    => { Digest => 'RIPEMD160', Version => 4 },
+              'sign'    => { Digest => 'SHA256', Version => 4 },
               'encrypt' => { Cipher => 'Rijndael', Compress => 'Zlib',
                              MDC => 1 },
-              'keygen'  => { Type => 'DSA', Cipher => 'Rijndael',
-                             Version => 4, Digest => 'RIPEMD160' },
+              'keygen'  => { Type => 'RSA', Cipher => 'Rijndael',
+                             Version => 4, Digest => 'SHA256' },
               'Config'  => [
                      $env->('GNUPGHOME', 'options'),
                      $home->( '.gnupg', 'options' ),


### PR DESCRIPTION
GnuPG now defaults to stronger algorithms than before.  As of the latest versions, it uses SHA-256 and RSA instead of RIPEMD-160 and DSA.  Update the GnuPG compatibility defaults to match these.

As a side note, GnuPG has supported SHA-256 since the version in CentOS 4, which lost security support in 2012.  Every reasonably modern OpenPGP implementation supports SHA-256, and most of them default to using it or one of the other SHA-2 functions.