### PR TITLE
Avoid DWIMmery on 0

### DIFF
--- a/lib/Crypt/OpenPGP/CFB.pm
+++ b/lib/Crypt/OpenPGP/CFB.pm
@@ -29,7 +29,7 @@ sub encrypt {
     my $iv = $c->{iv};
     my $out = $c->{unused} || '';
     my $size = length $out;
-    while ($data) {
+    while ( $data ne '' ) {
         unless ($size) {
             $out = $c->{cipher}->encrypt($iv);
             $size = $c->{blocksize};
@@ -52,7 +52,7 @@ sub decrypt {
     my $iv = $c->{iv};
     my $out = $c->{unused} || '';
     my $size = length $out;
-    while ($data) {
+    while ( $data ne '' ) {
         unless ($size) {
             $out = $c->{cipher}->encrypt($iv);
             $size = $c->{blocksize};

--- a/t/11-encrypt.t
+++ b/t/11-encrypt.t
@@ -1,5 +1,5 @@
 use strict;
-use Test::More tests => 36;
+use Test::More tests => 38;
 
 use Crypt::OpenPGP;
 use Crypt::OpenPGP::Message;
@@ -70,6 +70,18 @@ isa_ok $pgp, 'Crypt::OpenPGP';
 {
     # Now test conventional encryption; might as well just
     # reuse the passphrase.
+    my $ct = $pgp->encrypt(
+        Passphrase => $pass,
+        Data       => $text,
+    );
+    ok $ct, 'ciphertext is defined';
+    my $pt = $pgp->decrypt( Data => $ct, Passphrase => $pass );
+    is $pt, $text, 'decrypting yields original text';
+}
+
+{
+    # Test trailing zeroes.
+    my $text = '123456780';
     my $ct = $pgp->encrypt(
         Passphrase => $pass,
         Data       => $text,


### PR DESCRIPTION
When $data is 0, it is falsey, leading plaintext to be lost in the case that the next character is 0.