### PR TITLE
ElGamal: key's p can be a large integer, use Bigint

### DIFF
--- a/lib/Crypt/OpenPGP/Key/Public/ElGamal.pm
+++ b/lib/Crypt/OpenPGP/Key/Public/ElGamal.pm
@@ -53,7 +53,7 @@ sub gen_k {
     my($p) = @_;
     ## XXX choose bitsize based on bitsize of $p
     my $bits = 198;
-    my $p_minus1 = $p - 1;
+    my $p_minus1 = Math::BigInt->new($p) - 1;
 
     my $k = Crypt::OpenPGP::Util::get_random_bigint($bits);
     while (1) {


### PR DESCRIPTION
Fixes #30

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btrott/crypt-openpgp/31)
<!-- Reviewable:end -->
