### PR TITLE
solves error (Symkey decrypt failed: Invalid secret key ID)

### DIFF
--- a/lib/Crypt/OpenPGP.pm
+++ b/lib/Crypt/OpenPGP.pm
@@ -608,7 +608,7 @@ sub decrypt {
         return $pgp->error("Can't find a secret key to decrypt message")
             unless $kb || $cert;
         if ($kb) {
-            $cert = $kb->encrypting_key;
+            $cert = $kb->key_by_id($sym_key->key_id);
             $cert->uid($kb->primary_uid);
         }
         if ($cert->is_protected) {


### PR DESCRIPTION
"Symkey decrypt failed: Invalid secret key ID" problem in https://stackoverflow.com/questions/12540226/cryptopenpgp-symkey-decrypt-failed-invalid-secret-key-id .
I use openpgp.js for the encryption of messages and get the same error. It seems openpgp.js uses the subkey for encryption of the sessionkey. So I suggest "$kb->key_by_id($sym_key->key_id)" instead of "$kb->encrypting_key".